### PR TITLE
finishing #13 (update metadata.js)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
 		"3.2.0", 
 		"3.2.1",
         "3.4",
-        "3.4.1"
+        "3.4.1",
+        "3.6"
 	], 
 	"description": "Shows the title of windows in the status bar. FOR BEST RESULTS, USE THE Extend left box EXTENSION TO MAKE THE TITLE TAKE THE WHOLE AVAILABLE SPACE IN THE STATUS BAR",
     "version": 1,


### PR DESCRIPTION
@doublerebel [updated](https://github.com/emerinohdz/StatusTitleBar/pull/13) the extension to work with gnome 3.6, but did not update the `metadata.json` file. This is working fine on Arch Linux with gnome-shell 3.6.1
