### PR TITLE
Change title between multiple windows of same application

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -384,6 +384,11 @@ const StatusTitleBarButton = new Lang.Class({
         if (targetApp == this._targetApp) {
             if (targetApp && targetApp.get_state() != Shell.AppState.STARTING) {
                 this.stopAnimation();
+
+                let win = global.display.focus_window;
+                if (!win._notifyTitleId) { this._initWindow(win); }
+                this._changeTitle(win, targetApp);
+
                 this._maybeSetMenu();
             }
             return;


### PR DESCRIPTION
Fix suggested by @iamdvr in reply to @posty's request on July 13, 2013
https://extensions.gnome.org/extension/59/status-title-bar/
