### PR TITLE
Avoid error-ing out when shell provides a valid focused app but no matching window

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -422,6 +422,7 @@ const StatusTitleBarButton = new Lang.Class({
                 connectAndTrack(this._targetAppSignals, targetApp,
                     'notify::action-group', Lang.bind(this, this._sync));
             }
+        }
 
         this._targetApp = targetApp;
         let icon = targetApp.get_faded_icon(2 * PANEL_ICON_SIZE);


### PR DESCRIPTION
Check for a null window handle before trying to do all the title retrieval logic to avoid errors.

Also makes indentation uniform in extension.js, was bugging me out.
