### PR TITLE
Add support for GNOME 3.14

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,11 +1,12 @@
 {
-	"uuid": "StatusTitleBar@devpower.org", 
-	"name": "Status Title Bar", 
+	"uuid": "StatusTitleBar@devpower.org",
+	"name": "Status Title Bar",
 	"shell-version": [
         "3.8",
         "3.10",
-        "3.12"
-	], 
+        "3.12",
+        "3.14"
+	],
 	"description": "Shows the title of windows in the status bar. FOR BEST RESULTS, USE THE Extend left box EXTENSION TO MAKE THE TITLE TAKE THE WHOLE AVAILABLE SPACE IN THE STATUS BAR",
     "version": 1,
     "url":"https://github.com/emerinohdz/StatusTitleBar"


### PR DESCRIPTION
The extension works fine for me on Arch with GNOME 3.14 without any changes to the code.
I just added 3.14 to the list of supported shell versions.