### PR TITLE
Workaround removal of maximize and unmaximize signals for GS3.18

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,7 +2,8 @@
 	"uuid": "StatusTitleBar@devpower.org", 
 	"name": "Status Title Bar", 
 	"shell-version": [
-        "3.16"
+        "3.16",
+        "3.18"
 	], 
 	"description": "Shows the title of windows in the status bar. FOR BEST RESULTS, USE THE Extend left box EXTENSION TO MAKE THE TITLE TAKE THE WHOLE AVAILABLE SPACE IN THE STATUS BAR",
     "version": 1,


### PR DESCRIPTION
See gnome-shell https://git.gnome.org/browse/gnome-shell
Connect to size-changed signal
windowManager.js fe265554a7563d91d00525e35e43a3ff3e57effe
Adapt to new size-change API
windowManager.js 7305466765395e555278a3b26e9017387edb3a74

Signed-off-by: Norman L. Smith <nls1729@users.noreply.github.com>

Tested with F23 Beta GS 3.18.